### PR TITLE
Cleaning up charts page; using static links in href attribute instead of dynamic PHP code

### DIFF
--- a/app/View/Pages/charts.ctp
+++ b/app/View/Pages/charts.ctp
@@ -148,20 +148,21 @@ $urlWithoutArguments = substr($url, 0, strpos($url, '/charts'));
 
 <div class="btn-toolbar pagination-centered" role="toolbar">
   <div class="btn-group" role="group">
-	<a href="<?php echo($urlWithoutArguments);?>/charts/all" class="btn btn-default" <?php IF($argument=='all'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>All Members and Interns</a>
+	<a href="/pages/charts/all" class="btn btn-default" <?php IF($argument=='all'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>All Members and Interns
+    </a>
   </div>
   <div class="btn-group" role="group" aria-label="...">
-	<a href="<?php echo($urlWithoutArguments);?>/charts/maryland" class="btn btn-default" <?php IF($argument=='maryland'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Maryland</a>
-	<a href="<?php echo($urlWithoutArguments);?>/charts/dc" class="btn btn-default disabled" <?php IF($argument=='dc'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Washington DC</a>
-	<a href="<?php echo($urlWithoutArguments);?>/charts/virginia" class="btn btn-default" <?php IF($argument=='virginia'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Virginia</a>
+	<a href="/pages/charts/maryland" class="btn btn-default" <?php IF($argument=='maryland'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Maryland</a>
+	<a href="/pages/charts/dc" class="btn btn-default disabled" <?php IF($argument=='dc'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Washington DC</a>
+	<a href="/pages/charts/virginia" class="btn btn-default" <?php IF($argument=='virginia'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Virginia</a>
   </div>
   <div class="btn-group" role="group" aria-label="...">
-	<a href="<?php echo($urlWithoutArguments);?>/charts/montgomery" class="btn btn-default" <?php IF($argument=='montgomery'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Montgomery County</a>
-	<a href="<?php echo($urlWithoutArguments);?>/charts/princeGeorges" class="btn btn-default" <?php IF($argument=='princeGeorges'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Prince George's County</a>
-	<a href="<?php echo($urlWithoutArguments);?>/charts/baltimore" class="btn btn-default disabled" <?php IF($argument=='baltimore'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>City of Baltimore</a>
-	<a href="<?php echo($urlWithoutArguments);?>/charts/arlington" class="btn btn-default disabled" <?php IF($argument=='arlington'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Arlington County</a>
-	<a href="<?php echo($urlWithoutArguments);?>/charts/alexandria" class="btn btn-default" <?php IF($argument=='alexandria'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>City of Alexandria</a>
-	<a href="<?php echo($urlWithoutArguments);?>/charts/fairfax" class="btn btn-default" <?php IF($argument=='fairfax'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Fairfax County</a>
+	<a href="/pages/charts/montgomery" class="btn btn-default" <?php IF($argument=='montgomery'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Montgomery County</a>
+	<a href="/pages/charts/princeGeorges" class="btn btn-default" <?php IF($argument=='princeGeorges'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Prince George's County</a>
+	<a href="/pages/charts/baltimore" class="btn btn-default disabled" <?php IF($argument=='baltimore'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>City of Baltimore</a>
+	<a href="/pages/charts/arlington" class="btn btn-default disabled" <?php IF($argument=='arlington'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Arlington County</a>
+	<a href="/pages/charts/alexandria" class="btn btn-default" <?php IF($argument=='alexandria'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>City of Alexandria</a>
+	<a href="/pages/charts/fairfax" class="btn btn-default" <?php IF($argument=='fairfax'){echo('style="background-image: linear-gradient(#999,#999 5%,#999);"');} ?>>Fairfax County</a>
   </div>
 </div>
 <hr />
@@ -170,4 +171,3 @@ $urlWithoutArguments = substr($url, 0, strpos($url, '/charts'));
 <!--
 <div id="where_are_they_now_container" style="min-width: 310px; height: 400px"></div>
 -->
-


### PR DESCRIPTION
This file needed refactoring before I can work on the charts, so I started using static endpoints.  youth.libertyspromise.com uses relative endpoints, so this would be easier

It worked differently on my machine, since I would have to go via localhost/ClientTracker/pages/charts, so what I did was change htdocs to use a virtualhost; now when I go to localhost:80, it takes me directly to the client tracker application, and I can use relative paths there as well.
